### PR TITLE
Add MongoDB with Mongoose

### DIFF
--- a/.env
+++ b/.env
@@ -3,3 +3,5 @@ JWT_SECRET=supersecret
 JWT_EXPIRES_IN=15m
 REFRESH_SECRET=superrefreshsecret
 REFRESH_EXPIRES_IN=7d
+
+MONGO_URI=mongodb://localhost:27017/blogapi

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "dotenv": "^16.5.0",
         "express": "^5.1.0",
         "jsonwebtoken": "^9.0.2",
+        "mongoose": "^8.15.2",
         "morgan": "^1.10.0",
         "zod": "^3.22.4"
       },
@@ -38,6 +39,30 @@
       },
       "bin": {
         "node-pre-gyp": "bin/node-pre-gyp"
+      }
+    },
+    "node_modules/@mongodb-js/saslprep": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@mongodb-js/saslprep/-/saslprep-1.3.0.tgz",
+      "integrity": "sha512-zlayKCsIjYb7/IdfqxorK5+xUMyi4vOKcFy10wKJYc63NSdKI8mNME+uJqfatkPmOSMMUiojrL58IePKBm3gvQ==",
+      "license": "MIT",
+      "dependencies": {
+        "sparse-bitfield": "^3.0.3"
+      }
+    },
+    "node_modules/@types/webidl-conversions": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/@types/webidl-conversions/-/webidl-conversions-7.0.3.tgz",
+      "integrity": "sha512-CiJJvcRtIgzadHCYXw7dqEnMNRjhGZlYK05Mj9OyktqV8uVT8fD2BFOB7S1uwBE3Kj2Z+4UyPmFw/Ixgw/LAlA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/whatwg-url": {
+      "version": "11.0.5",
+      "resolved": "https://registry.npmjs.org/@types/whatwg-url/-/whatwg-url-11.0.5.tgz",
+      "integrity": "sha512-coYR071JRaHa+xoEvvYqvnIHaVqaYrLPbsufM9BF63HkwI5Lgmy2QR8Q5K/lYDYo5AK82wOvSOS0UsLTpTG7uQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/webidl-conversions": "*"
       }
     },
     "node_modules/abbrev": {
@@ -206,6 +231,15 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/bson": {
+      "version": "6.10.4",
+      "resolved": "https://registry.npmjs.org/bson/-/bson-6.10.4.tgz",
+      "integrity": "sha512-WIsKqkSC0ABoBJuT1LEX+2HEvNmNKKgnTAyd0fL8qzK4SH2i9NXg+t08YtdZp/V9IZ33cxe3iV4yM0qg8lMQng==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=16.20.1"
       }
     },
     "node_modules/buffer-equal-constant-time": {
@@ -963,6 +997,15 @@
         "safe-buffer": "^5.0.1"
       }
     },
+    "node_modules/kareem": {
+      "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/kareem/-/kareem-2.6.3.tgz",
+      "integrity": "sha512-C3iHfuGUXK2u8/ipq9LfjFfXFxAZMQJJq7vLS45r3D9Y2xQ/m4S8zaR4zMLFWh9AsNPXmcFfUDhTEO8UIC/V6Q==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/lodash.includes": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
@@ -1046,6 +1089,12 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/memory-pager": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/memory-pager/-/memory-pager-1.5.0.tgz",
+      "integrity": "sha512-ZS4Bp4r/Zoeq6+NLJpP+0Zzm0pR8whtGPf1XExKLJBAczGMnSi3It14OiNCStjQjM6NU1okjQGSxgEZN8eBYKg==",
+      "license": "MIT"
     },
     "node_modules/merge-descriptors": {
       "version": "2.0.0",
@@ -1138,6 +1187,118 @@
         "node": ">=10"
       }
     },
+    "node_modules/mongodb": {
+      "version": "6.16.0",
+      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-6.16.0.tgz",
+      "integrity": "sha512-D1PNcdT0y4Grhou5Zi/qgipZOYeWrhLEpk33n3nm6LGtz61jvO88WlrWCK/bigMjpnOdAUKKQwsGIl0NtWMyYw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@mongodb-js/saslprep": "^1.1.9",
+        "bson": "^6.10.3",
+        "mongodb-connection-string-url": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=16.20.1"
+      },
+      "peerDependencies": {
+        "@aws-sdk/credential-providers": "^3.188.0",
+        "@mongodb-js/zstd": "^1.1.0 || ^2.0.0",
+        "gcp-metadata": "^5.2.0",
+        "kerberos": "^2.0.1",
+        "mongodb-client-encryption": ">=6.0.0 <7",
+        "snappy": "^7.2.2",
+        "socks": "^2.7.1"
+      },
+      "peerDependenciesMeta": {
+        "@aws-sdk/credential-providers": {
+          "optional": true
+        },
+        "@mongodb-js/zstd": {
+          "optional": true
+        },
+        "gcp-metadata": {
+          "optional": true
+        },
+        "kerberos": {
+          "optional": true
+        },
+        "mongodb-client-encryption": {
+          "optional": true
+        },
+        "snappy": {
+          "optional": true
+        },
+        "socks": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/mongodb-connection-string-url": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mongodb-connection-string-url/-/mongodb-connection-string-url-3.0.2.tgz",
+      "integrity": "sha512-rMO7CGo/9BFwyZABcKAWL8UJwH/Kc2x0g72uhDWzG48URRax5TCIcJ7Rc3RZqffZzO/Gwff/jyKwCU9TN8gehA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/whatwg-url": "^11.0.2",
+        "whatwg-url": "^14.1.0 || ^13.0.0"
+      }
+    },
+    "node_modules/mongodb-connection-string-url/node_modules/tr46": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz",
+      "integrity": "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==",
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/mongodb-connection-string-url/node_modules/webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/mongodb-connection-string-url/node_modules/whatwg-url": {
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz",
+      "integrity": "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==",
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "^5.1.0",
+        "webidl-conversions": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/mongoose": {
+      "version": "8.15.2",
+      "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-8.15.2.tgz",
+      "integrity": "sha512-GLwghI2dS/n5BTBljspF4+FsCEBeHgnMQyX8GloYkLkl+MKljKkjcP9DhLr47Yod2RO1RCr4vZ3evUZAyuoILw==",
+      "license": "MIT",
+      "dependencies": {
+        "bson": "^6.10.3",
+        "kareem": "2.6.3",
+        "mongodb": "~6.16.0",
+        "mpath": "0.9.0",
+        "mquery": "5.0.0",
+        "ms": "2.1.3",
+        "sift": "17.1.3"
+      },
+      "engines": {
+        "node": ">=16.20.1"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mongoose"
+      }
+    },
     "node_modules/morgan": {
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/morgan/-/morgan-1.10.0.tgz",
@@ -1179,6 +1340,27 @@
       },
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/mpath": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/mpath/-/mpath-0.9.0.tgz",
+      "integrity": "sha512-ikJRQTk8hw5DEoFVxHG1Gn9T/xcjtdnOKIU1JTmGjZZlg9LST2mBLmcX3/ICIbgJydT2GOc15RnNy5mHmzfSew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/mquery": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/mquery/-/mquery-5.0.0.tgz",
+      "integrity": "sha512-iQMncpmEK8R8ncT8HJGsGc9Dsp8xcgYMVSbs5jgnm1lFHTZqMJTUWTDx1LBO8+mK3tPNZWFLBghQEIOULSTHZg==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "4.x"
+      },
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/ms": {
@@ -1399,6 +1581,15 @@
       "integrity": "sha512-77DZwxQmxKnu3aR542U+X8FypNzbfJ+C5XQDk3uWjWxn6151aIMGthWYRXTqT1E5oJvg+ljaa2OJi+VfvCOQ8w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/qs": {
       "version": "6.14.0",
@@ -1657,6 +1848,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/sift": {
+      "version": "17.1.3",
+      "resolved": "https://registry.npmjs.org/sift/-/sift-17.1.3.tgz",
+      "integrity": "sha512-Rtlj66/b0ICeFzYTuNvX/EF1igRbbnGSvEyT79McoZa/DeGhMyC5pWKOEsZKnpkqtSeovd5FL/bjHWC3CIIvCQ==",
+      "license": "MIT"
+    },
     "node_modules/signal-exit": {
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
@@ -1674,6 +1871,15 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/sparse-bitfield": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/sparse-bitfield/-/sparse-bitfield-3.0.3.tgz",
+      "integrity": "sha512-kvzhi7vqKTfkh0PZU+2D2PIllw2ymqJKujUcyPMd9Y75Nv4nPbGJZXNhxsgdQab2BmlDct1YnfQCguEvHr7VsQ==",
+      "license": "MIT",
+      "dependencies": {
+        "memory-pager": "^1.0.2"
       }
     },
     "node_modules/statuses": {

--- a/package.json
+++ b/package.json
@@ -12,12 +12,13 @@
   "license": "ISC",
   "type": "module",
   "dependencies": {
+    "bcrypt": "^5.1.1",
     "dotenv": "^16.5.0",
     "express": "^5.1.0",
+    "jsonwebtoken": "^9.0.2",
+    "mongoose": "^8.15.2",
     "morgan": "^1.10.0",
-    "zod": "^3.22.4",
-    "bcrypt": "^5.1.1",
-    "jsonwebtoken": "^9.0.2"
+    "zod": "^3.22.4"
   },
   "devDependencies": {
     "nodemon": "^3.1.10"

--- a/src/config/db.js
+++ b/src/config/db.js
@@ -1,6 +1,12 @@
-// Placeholder for database configuration
-// In-memory store for posts
-export const db = {
-  posts: [],
-  users: [], // in-memory user store
+import mongoose from 'mongoose';
+import { env } from './env.js';
+
+export const connectDB = async () => {
+  try {
+    await mongoose.connect(env.mongoUri);
+    console.log('MongoDB connected');
+  } catch (err) {
+    console.error('MongoDB connection error:', err.message);
+    process.exit(1);
+  }
 };

--- a/src/config/env.js
+++ b/src/config/env.js
@@ -7,4 +7,5 @@ export const env = {
   jwtExpiresIn: process.env.JWT_EXPIRES_IN || '15m',
   refreshSecret: process.env.REFRESH_SECRET || 'changeMeToo',
   refreshExpiresIn: process.env.REFRESH_EXPIRES_IN || '7d',
+  mongoUri: process.env.MONGO_URI || 'mongodb://localhost:27017/blogapi',
 };

--- a/src/middlewares/error.middleware.ts
+++ b/src/middlewares/error.middleware.ts
@@ -1,4 +1,5 @@
 import { Request, Response, NextFunction } from 'express';
+import mongoose from 'mongoose';
 
 interface HttpError extends Error {
   status?: number;
@@ -11,5 +12,14 @@ export const errorMiddleware = (
   _next: NextFunction
 ): void => {
   console.error(err);
+  if (err instanceof mongoose.Error.ValidationError) {
+    const first = Object.values(err.errors)[0];
+    res.status(400).json({ message: first?.message || 'Validation error' });
+    return;
+  }
+  if (err instanceof mongoose.Error.CastError) {
+    res.status(400).json({ message: 'Invalid ' + err.path });
+    return;
+  }
   res.status(err.status ?? 500).json({ message: err.message || 'Internal Server Error' });
 };

--- a/src/models/post.model.js
+++ b/src/models/post.model.js
@@ -1,0 +1,11 @@
+import mongoose from 'mongoose';
+
+const postSchema = new mongoose.Schema(
+  {
+    title: { type: String, required: true },
+    content: { type: String, required: true },
+  },
+  { timestamps: true }
+);
+
+export const Post = mongoose.model('Post', postSchema);

--- a/src/models/user.model.js
+++ b/src/models/user.model.js
@@ -1,7 +1,8 @@
-export class User {
-  constructor({ id, email, passwordHash }) {
-    this.id = id;
-    this.email = email;
-    this.passwordHash = passwordHash;
-  }
-}
+import mongoose from 'mongoose';
+
+const userSchema = new mongoose.Schema({
+  email: { type: String, required: true, unique: true },
+  password: { type: String, required: true },
+});
+
+export const User = mongoose.model('User', userSchema);

--- a/src/server.js
+++ b/src/server.js
@@ -1,6 +1,8 @@
 import app from './app.js';
 import { env } from './config/env.js';
-
-app.listen(env.port, () => {
-  console.log(`Server running on port ${env.port}`);
+import { connectDB } from './config/db.js';
+connectDB().then(() => {
+  app.listen(env.port, () => {
+    console.log(`Server running on port ${env.port}`);
+  });
 });

--- a/src/services/auth.service.js
+++ b/src/services/auth.service.js
@@ -1,28 +1,24 @@
 import bcrypt from 'bcrypt';
-import { db } from '../config/db.js';
 import { User } from '../models/user.model.js';
 import { tokenService } from './token.service.js';
 
-let userIdCounter = 1;
-
 export const register = async ({ email, password }) => {
-  const existing = db.users.find((u) => u.email === email);
+  const existing = await User.findOne({ email }).lean();
   if (existing) {
     throw Object.assign(new Error('Email already in use'), { status: 409 });
   }
-  const passwordHash = await bcrypt.hash(password, 10);
-  const user = new User({ id: userIdCounter++, email, passwordHash });
-  db.users.push(user);
+  const hash = await bcrypt.hash(password, 10);
+  const user = await User.create({ email, password: hash });
   const tokens = tokenService.generateTokens({ sub: user.id });
   return { user: { id: user.id, email: user.email }, ...tokens };
 };
 
 export const login = async ({ email, password }) => {
-  const user = db.users.find((u) => u.email === email);
+  const user = await User.findOne({ email });
   if (!user) {
     throw Object.assign(new Error('Invalid credentials'), { status: 401 });
   }
-  const match = await bcrypt.compare(password, user.passwordHash);
+  const match = await bcrypt.compare(password, user.password);
   if (!match) {
     throw Object.assign(new Error('Invalid credentials'), { status: 401 });
   }

--- a/src/services/post.service.ts
+++ b/src/services/post.service.ts
@@ -1,39 +1,25 @@
-import { db } from '../config/db.js';
-import type { Post } from '../models/post.model.js';
+import { Post } from '../models/post.model.js';
 
-let idCounter = 1;
-
-export const createPost = async ({ title, content }: { title: string; content: string }): Promise<Post> => {
-  const post: Post = {
-    id: idCounter++,
-    title,
-    content,
-    createdAt: new Date(),
-    updatedAt: new Date(),
-  };
-  db.posts.push(post);
-  return post;
+export const createPost = async ({ title, content }: { title: string; content: string }) => {
+  const post = await Post.create({ title, content });
+  return post.toObject();
 };
 
-export const getPosts = async (): Promise<Post[]> => db.posts;
+export const getPosts = async () => Post.find().lean();
 
-export const getPostById = async (id: number): Promise<Post | undefined> => db.posts.find((p) => p.id === id);
+export const getPostById = async (id: string) => Post.findById(id).lean();
 
 export const updatePost = async (
-  id: number,
+  id: string,
   { title, content }: { title?: string; content?: string }
-): Promise<Post | null> => {
-  const post = db.posts.find((p) => p.id === id);
-  if (!post) return null;
-  if (title !== undefined) post.title = title;
-  if (content !== undefined) post.content = content;
-  post.updatedAt = new Date();
-  return post;
-};
+) =>
+  Post.findByIdAndUpdate(
+    id,
+    { $set: { title, content } },
+    { new: true, runValidators: true }
+  ).lean();
 
-export const deletePost = async (id: number): Promise<boolean> => {
-  const index = db.posts.findIndex((p) => p.id === id);
-  if (index === -1) return false;
-  db.posts.splice(index, 1);
-  return true;
+export const deletePost = async (id: string) => {
+  const result = await Post.findByIdAndDelete(id);
+  return !!result;
 };


### PR DESCRIPTION
## Summary
- connect to MongoDB with Mongoose
- store config for Mongo URL in `.env`
- implement Mongoose User and Post models
- update services to use MongoDB
- improve error middleware for Mongoose errors
- start server only after database connects

## Testing
- `npm start` *(fails: Cannot find module logger.js)*

------
https://chatgpt.com/codex/tasks/task_e_684ffa740b648333a8b138603572a671